### PR TITLE
Null-check for JPropNode byName map.

### DIFF
--- a/src/main/java/com/fasterxml/jackson/dataformat/javaprop/util/JPropNode.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/javaprop/util/JPropNode.java
@@ -56,6 +56,10 @@ public class JPropNode
     }
     
     public JPropNode addByName(String name) {
+        if (_byName == null) {
+            _byName = new LinkedHashMap<>();
+        }
+
         // if former index entries, first coerce them
         _hasContents = true;
         if (_byIndex != null) {
@@ -64,14 +68,11 @@ public class JPropNode
             }
             _byIndex = null;
         }
-        if (_byName == null) {
-            _byName = new LinkedHashMap<>();
-        } else {
-            JPropNode old = _byName.get(name);
-            if (old != null) {
-                return old;
-            }
+        JPropNode old = _byName.get(name);
+        if (old != null) {
+            return old;
         }
+
         JPropNode result = new JPropNode();
         _byName.put(name, result);
         return result;


### PR DESCRIPTION
Hi team
I have the following:
```
public class Config {
...
    public Map<String, Comparison> comparison = Collections.emptyMap();
...
}

@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "name", resolver = SimpleObjectIdResolver.class)
public class Comparison {
    @JsonIdentityReference(alwaysAsId = true)
    public String name;
...
    public String database;
...
}
```
I forgot to set the `comparison` name in the properties file:
```
comparison.source.database=test
comparison.target.database=test2
```

This caused an NPE in JPropNode
```
java.lang.NullPointerException
	at com.fasterxml.jackson.dataformat.javaprop.util.JPropNode.addByName(JPropNode.java:63)
	at com.fasterxml.jackson.dataformat.javaprop.util.JPropPathSplitter._addSegment(JPropPathSplitter.java:77)
	at com.fasterxml.jackson.dataformat.javaprop.util.JPropPathSplitter$CharPathOnlySplitter.splitAndAdd(JPropPathSplitter.java:160)
	at com.fasterxml.jackson.dataformat.javaprop.util.JPropPathSplitter$FullSplitter.splitAndAdd(JPropPathSplitter.java:285)
	at com.fasterxml.jackson.dataformat.javaprop.util.JPropNodeBuilder.build(JPropNodeBuilder.java:21)
	at com.fasterxml.jackson.dataformat.javaprop.JavaPropsParser.nextToken(JavaPropsParser.java:218)
	at com.fasterxml.jackson.databind.ObjectMapper._initForReading(ObjectMapper.java:3834)
	at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:3783)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:2908)
	at org.someth2say.tablecomparer.config.ConfigTest.testLoadPropertiesConfig(ConfigTest.java:35)
	...
```
Checking the code, I realized JNodeProp is accessing `_byName` property before it is being set (see https://github.com/FasterXML/jackson-dataformat-properties/blob/78fd4f1a847510c571f14e697a801587299e7785/src/main/java/com/fasterxml/jackson/dataformat/javaprop/util/JPropNode.java#L58)

So here you got a PR!

